### PR TITLE
Sundials 3 and 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ install:
   - pip install cython numpy
   - pip install .[test]
   # Needed to upload coverage results
+  - pip install pytest>=3.6
   - pip install codecov
   # Check what's installed
   - python --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,10 @@ install:
   - pip install cython numpy
   - pip install .[test]
   # Needed to upload coverage results
-  - pip install pytest>=3.6
   - pip install codecov
   # Check what's installed
   - python --version
+  - pytest --version
   - flake8 --version
 script:
   - flake8

--- a/fc/sundials/solver.pxd
+++ b/fc/sundials/solver.pxd
@@ -5,6 +5,10 @@ cimport fc.sundials.sundials as _lib
 # Save typing
 ctypedef _lib.N_Vector N_Vector
 ctypedef np.float64_t realtype
+IF FC_SUNDIALS_MAJOR >= 3:
+    ctypedef _lib.SUNMatrix SUNMatrix
+    ctypedef _lib.SUNLinearSolver SUNLinearSolver
+
 
 #cdef object NumpyView(N_Vector v)
 
@@ -12,9 +16,10 @@ ctypedef np.float64_t realtype
 
 cdef class CvodeSolver:
     cdef void* cvode_mem # CVODE solver 'object'
+
     cdef N_Vector _state # The state vector of the model being simulated
     cdef int _state_size # The number of state variables / length of the state vector
-    
+
     cdef public np.ndarray state # Numpy view of the state vector
     cdef public object model # The model being simulated
 
@@ -22,6 +27,12 @@ cdef class CvodeSolver:
     cpdef ResetSolver(self, np.ndarray[realtype, ndim=1] resetTo)
     cpdef SetFreeVariable(self, realtype t)
     cpdef Simulate(self, realtype endPoint)
-    
+
     cdef ReInit(self)
     cdef CheckFlag(self, int flag, char* called)
+
+    IF FC_SUNDIALS_MAJOR >= 3:
+        # Linear matrix solving in sundials 3+
+        cdef SUNMatrix sundense_matrix
+        cdef SUNLinearSolver sundense_solver
+

--- a/fc/sundials/solver.pyx
+++ b/fc/sundials/solver.pyx
@@ -53,12 +53,21 @@ cdef class CvodeSolver:
         self._state = NULL
         self._state_size = 0
 
+        IF FC_SUNDIALS_MAJOR >= 3:
+            self.sundense_matrix = NULL
+            self.sundense_solver = NULL
+
     def __dealloc__(self):
         """Free solver memory if allocated."""
         if self.cvode_mem != NULL:
             _lib.CVodeFree(&self.cvode_mem)
         if self._state != NULL:
             _lib.N_VDestroy_Serial(self._state)
+        IF FC_SUNDIALS_MAJOR >= 3:
+            if self.sundense_solver != NULL:
+                _lib.SUNLinSolFree(self.sundense_solver)
+            if self.sundense_matrix != NULL:
+                _lib.SUNMatDestroy(self.sundense_matrix)
 
     def __init__(self):
         """Python level object initialisation."""
@@ -72,11 +81,13 @@ cdef class CvodeSolver:
         if self._state != NULL:
             _lib.N_VDestroy_Serial(self._state)
         self.model = model
+
         # Set our internal state vector as an N_Vector wrapper around the numpy state.
         assert isinstance(model.state, np.ndarray)
         self.state = model.state
         self._state_size = len(model.state)
         self._state = _lib.N_VMake_Serial(self._state_size, <realtype*>(<np.ndarray>self.state).data)
+
         # Initialise CVODE
         self.cvode_mem = _lib.CVodeCreate(_lib.CV_BDF, _lib.CV_NEWTON)
         if hasattr(self, 'SetRhsWrapper'):
@@ -91,9 +102,25 @@ cdef class CvodeSolver:
         reltol = 1e-6
         flag = _lib.CVodeSStolerances(self.cvode_mem, reltol, abstol)
         self.CheckFlag(flag, 'CVodeSStolerances')
+
+        # Create dense matrix for use in linear solves
         if self._state_size > 0:
-            flag = _lib.CVDense(self.cvode_mem, self._state_size)
-            self.CheckFlag(flag, 'CVDense')
+            IF FC_SUNDIALS_MAJOR >= 3:
+                # Create dense matrix
+                self.sundense_matrix = _lib.SUNDenseMatrix(self._state_size, self._state_size)
+                # Not sure how to check these now! See comments for CheckFlag below
+                #self.CheckFlag(<void*>self.sundense_matrix, 'SUNDenseMatrix')
+                # Create linear solver
+                self.sundense_solver = _lib.SUNDenseLinearSolver(self._state, self.sundense_matrix)
+                #self.CheckFlag(<void*>self.sundense_solver, 'SUNDenseLinearSolver')
+                # Tell cvode to use this solver
+                flag = _lib.CVDlsSetLinearSolver(self.cvode_mem, self.sundense_solver, self.sundense_matrix)
+                self.CheckFlag(flag, 'CVDlsSetLinearSolver')
+            ELSE:
+                # Create dense matrix
+                flag = _lib.CVDense(self.cvode_mem, self._state_size)
+                self.CheckFlag(flag, 'CVDense')
+
         _lib.CVodeSetMaxNumSteps(self.cvode_mem, 20000000)
         _lib.CVodeSetMaxStep(self.cvode_mem, 0.5)
         _lib.CVodeSetMaxErrTestFails(self.cvode_mem, 15)
@@ -131,6 +158,9 @@ cdef class CvodeSolver:
 
     cdef CheckFlag(self, int flag, char* called):
         """Check for a successful call to a CVODE routine, and report the error if not."""
+        #TODO: Sundials can also return a null pointer instead of an int, the
+        # example implementation has a void* signature and then casts/dereferences
+        # to int
         if flag != _lib.CV_SUCCESS:
             flag_name = _lib.CVodeGetReturnFlagName(flag)
             raise ProtocolError("Error calling CVODE routine %s: %s" % (called, flag_name))

--- a/fc/sundials/sundials.pxd
+++ b/fc/sundials/sundials.pxd
@@ -8,6 +8,7 @@ Based on http://code.google.com/p/python-sundials/source/browse/trunk/sundials/S
 """
 
 cdef extern from "sundials/sundials_types.h":
+    ctypedef long int sunindextype
     ctypedef double realtype
     ctypedef bint booleantype
 
@@ -124,5 +125,28 @@ cdef extern from "cvode/cvode.h":
     char *CVodeGetReturnFlagName(int flag)
     void CVodeFree(void **cvode_mem)
 
-cdef extern from "cvode/cvode_dense.h":
-    int CVDense(void *cvode_mem, int N)
+IF FC_SUNDIALS_MAJOR >= 3:
+    cdef extern from "sundials/sundials_matrix.h":
+        ctypedef struct _generic_SUNMatrix:
+            pass
+        ctypedef _generic_SUNMatrix* SUNMatrix
+        void SUNMatDestroy(SUNMatrix A)
+
+    cdef extern from "sunmatrix/sunmatrix_dense.h":
+        SUNMatrix SUNDenseMatrix(sunindextype M, sunindextype N)
+
+    cdef extern from "sunlinsol/sunlinsol_dense.h":
+        ctypedef struct _generic_SUNLinearSolver:
+            pass
+        ctypedef _generic_SUNLinearSolver* SUNLinearSolver
+        void SUNLinSolFree(SUNLinearSolver)
+
+    cdef extern from "sundials/sundials_linearsolver.h":
+        SUNLinearSolver SUNDenseLinearSolver(N_Vector y, SUNMatrix A)
+
+    cdef extern from "cvode/cvode_direct.h":
+        int CVDlsSetLinearSolver(void* cvode_mem, SUNLinearSolver LS, SUNMatrix A)
+ELSE:
+    cdef extern from "cvode/cvode_dense.h":
+        int CVDense(void *cvode_mem, int N)
+

--- a/fc/sundials/sundials.pxd
+++ b/fc/sundials/sundials.pxd
@@ -68,7 +68,13 @@ cdef extern from "cvode/cvode.h":
     ctypedef int (*CVRhsFn)(realtype t, N_Vector y, N_Vector ydot, void *user_data)
     ctypedef int (*CVRootFn)(realtype t, N_Vector y, realtype *gout, void *user_data)
 
-    void *CVodeCreate(int lmm, int iter)
+    # In version 4 Newton iteration became the default, and a new syntax was
+    # introduced to change it (which we don't need to use here)
+    IF FC_SUNDIALS_MAJOR >= 4:
+        void *CVodeCreate(int lmm)
+    ELSE:
+        void *CVodeCreate(int lmm, int iter)
+
     int CVodeSetUserData(void *cvode_mem, void *user_data)
     int CVodeInit(void *cvode_mem, CVRhsFn f, realtype t0, N_Vector y0)
     int CVodeReInit(void *cvode_mem, realtype t0, N_Vector y0)

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         ],
         'test': [
             'flake8>=3.6',
-            'pytest',
+            'pytest>=3.6',
             'pytest-cov',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -6,28 +6,50 @@ At present, this just exists to allow us to build our Cython SUNDIALS wrapper.
 If SUNDIALS is installed in a non-standard location, it requires environment variables
 (CFLAGS and LDFLAGS) to have been set up before running.
 """
-
-
 import numpy
+
+from cython import inline
 from Cython.Distutils import build_ext
-# from distutils.core import setup
-from distutils.extension import Extension
+from Cython.Distutils.extension import Extension
 from setuptools import find_packages, setup
 
+# Detect major sundials version (defaults to 2)
+sundials_major = inline('''
+    cdef extern from *:
+        """
+        #include <sundials/sundials_config.h>
 
+        #ifndef SUNDIALS_VERSION_MAJOR
+            #define SUNDIALS_VERSION_MAJOR 2
+        #endif
+        """
+        int SUNDIALS_VERSION_MAJOR
+
+    return SUNDIALS_VERSION_MAJOR
+    ''')
+print('Building for Sundials ' + str(sundials_major) + '.x')
+
+# Define Cython modules
 ext_modules = [
     Extension('fc.sundials.sundials',
               sources=['fc/sundials/sundials.pxd'],
               include_dirs=['.', numpy.get_include()],
-              libraries=['sundials_cvode', 'sundials_nvecserial']),
+              libraries=['sundials_cvode', 'sundials_nvecserial'],
+              cython_compile_time_env={'FC_SUNDIALS_MAJOR': sundials_major},
+              ),
     Extension('fc.sundials.solver',
               sources=['fc/sundials/solver.pyx'],
               include_dirs=['.', numpy.get_include()],
-              libraries=['sundials_cvode', 'sundials_nvecserial'])
+              libraries=['sundials_cvode', 'sundials_nvecserial'],
+              cython_compile_time_env={'FC_SUNDIALS_MAJOR': sundials_major},
+              ),
 ]
+
+# Load readme for use as long description
 with open('README.md') as f:
     readme = f.read()
 
+# Setup
 setup(
     name='fc',
     version='0.1.0',


### PR DESCRIPTION
This seems to work (`TestModelSimulations.py` runs without error), and addresses both #7 and #8 

The sundials version is determined using inline Cython in setup.py; this assumes Cython is already up and running, but I guess that's allowed as we're already using cython imports in the same script...
