### PR TITLE
Update pyparsing version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 cache: pip
 python:
-  - "3.6"
+  - "3.5"
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 cache: pip
 python:
   - "3.5"
+  - "3.6"
 addons:
   apt:
     packages:

--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'matplotlib',
         'numexpr',
         'numpy',
-        'pyparsing<2.4',
+        'pyparsing!=2.4.2',
         'scipy',
         'tables',
         # 'weblab_cg',      # Add this in when weblab_cg is ready


### PR DESCRIPTION
See #49 

New version 2.4.3 is out, fixes issue. It worked with older versions too, so now setup.py just disallows 2.4.2