### PR TITLE
Updated version requirement for pyparsing.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -82,7 +82,7 @@ setup(
         'matplotlib',
         'numexpr',
         'numpy',
-        'pyparsing<2.4',
+        'pyparsing!=2.4.2',
         'scipy',
         'tables',
         # 'weblab_cg',      # Add this in when weblab_cg is ready


### PR DESCRIPTION
See #49

New version 2.4.3 is out, fixes issue. It worked with older versions too, so now setup.py just disallows 2.4.2