### PR TITLE
FileNotFound should return a clean exception

### DIFF
--- a/fc/protocol.py
+++ b/fc/protocol.py
@@ -81,6 +81,19 @@ class Protocol(object):
 
         The protocol must be specified using the textual syntax, as defined by the CompactSyntaxParser module.
         """
+        # if the filename passed as argument to CompactSyntaxParser is not found
+        # it tries to read it before checking it exists
+        # and you get a messy exit
+        # file_contents = file_or_filename.read()
+        #     E AttributeError: 'str' object has no attribute 'read'
+        #
+        #     During handling of the above exception, another exception occurred:
+        #     E FileNotFoundError: [Errno 2] No such file or directory:
+        # throw exception
+
+        with open(proto_file) as f:
+            f.close()
+
         self.proto_file = proto_file
         self.proto_name = os.path.basename(self.proto_file)
 

--- a/test/protocols/test_non_existent_library.txt
+++ b/test/protocols/test_non_existent_library.txt
@@ -1,0 +1,39 @@
+# Test using the original definition when replacing an equation.
+
+namespace oxmeta = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
+namespace test = "urn:test-ns#"
+
+import std = "BasicLibrary.txt"
+
+units {
+    mV = milli volt
+    ms = milli second
+    mV_per_ms = mV . ms^-1
+}
+
+model interface {
+    output oxmeta:membrane_voltage units mV
+    output test:parameter_a
+    output test:parameter_b
+
+    define diff(oxmeta:membrane_voltage; oxmeta:time) = 10 :: mV_per_ms + original_definition  # i.e. 10 + a
+    define test:parameter_b = (5 :: dimensionless * original_definition) - original_definition # i.e. (5*(-1)) - (-1) = -4
+    define test:parameter_a = 1 :: mV_per_ms + original_definition
+}
+
+tasks {
+    simulation sim = timecourse {
+        range t units ms uniform 0:5
+    }
+}
+
+post-processing {
+    assert std:Close(sim:membrane_voltage, [12*i for i in 0:6])
+    assert sim:parameter_a[0] == 2
+    assert sim:parameter_b[0] == -4
+}
+
+outputs {
+    V = sim:membrane_voltage
+    b = sim:parameter_b
+}

--- a/test/protocols/test_non_existent_library.txt
+++ b/test/protocols/test_non_existent_library.txt
@@ -3,7 +3,7 @@
 namespace oxmeta = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
 namespace test = "urn:test-ns#"
 
-import std = "BasicLibrary.txt"
+import std = "NonExistLibrary.txt"
 
 units {
     mV = milli volt

--- a/test/protocols/test_non_existent_library.txt
+++ b/test/protocols/test_non_existent_library.txt
@@ -1,24 +1,15 @@
-# Test using the original definition when replacing an equation.
-
-namespace oxmeta = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
-namespace test = "urn:test-ns#"
+# Check we get an error when a library file doesn't exist
 
 import std = "NonExistLibrary.txt"
 
 units {
     mV = milli volt
     ms = milli second
-    mV_per_ms = mV . ms^-1
 }
 
 model interface {
+    output oxmeta:time units ms
     output oxmeta:membrane_voltage units mV
-    output test:parameter_a
-    output test:parameter_b
-
-    define diff(oxmeta:membrane_voltage; oxmeta:time) = 10 :: mV_per_ms + original_definition  # i.e. 10 + a
-    define test:parameter_b = (5 :: dimensionless * original_definition) - original_definition # i.e. (5*(-1)) - (-1) = -4
-    define test:parameter_a = 1 :: mV_per_ms + original_definition
 }
 
 tasks {
@@ -27,13 +18,7 @@ tasks {
     }
 }
 
-post-processing {
-    assert std:Close(sim:membrane_voltage, [12*i for i in 0:6])
-    assert sim:parameter_a[0] == 2
-    assert sim:parameter_b[0] == -4
-}
-
 outputs {
     V = sim:membrane_voltage
-    b = sim:parameter_b
+    t = sim:time
 }

--- a/test/test_parsing_errors.py
+++ b/test/test_parsing_errors.py
@@ -4,17 +4,20 @@ import pytest
 import fc
 
 
-def test_non_existent():
+def test_non_existent_protocol():
+    # Checks that a missing protocol file is handled cleanly
     proto_file = 'protocols/not_here.txt'
     with pytest.raises(FileNotFoundError):
         fc.Protocol(proto_file)
 
 def test_non_existent_library():
+    # Checks that a missing imported library is handled cleanly
     proto_file = 'test/protocols/test_non_existent_library.txt'
     with pytest.raises(FileNotFoundError):
         fc.Protocol(proto_file)
 
 def test_protocol_error():
+    # Checks that running a protocol with an error in it reports this cleanly
     proto_file = 'test/protocols/test_error_msg.txt'
     proto = fc.Protocol(proto_file)
     with pytest.raises(fc.error_handling.ErrorRecorder):

--- a/test/test_parsing_errors.py
+++ b/test/test_parsing_errors.py
@@ -1,0 +1,21 @@
+
+import pytest
+
+import fc
+
+
+def test_non_existent():
+    proto_file = 'protocols/not_here.txt'
+    with pytest.raises(FileNotFoundError):
+        fc.Protocol(proto_file)
+
+def test_non_existent_library():
+    proto_file = 'test/protocols/test_non_existent_library.txt'
+    with pytest.raises(FileNotFoundError):
+        fc.Protocol(proto_file)
+
+def test_protocol_error():
+    proto_file = 'test/protocols/test_error_msg.txt'
+    proto = fc.Protocol(proto_file)
+    with pytest.raises(fc.error_handling.ErrorRecorder):
+        proto.run()

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -664,6 +664,10 @@ class TestSyntaxInterface(unittest.TestCase):
         proto.set_model(Model.TestOdeModel(1))
         proto.run()
 
+    def test_non_existent(self):
+        proto_file = 'protocols/not_here.txt'
+        # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
+
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)
         expr = parse_action[0].expr()

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -681,12 +681,11 @@ class TestSyntaxInterface(unittest.TestCase):
         for each in expr:
             self.assertIsInstance(each, S.Assign)
 
-        # test below is just to test that we get the correct output for a protocol error
-        # TODO - it's commented out because it causes a protocol error every time
-#     def test_protocol_error(self):
-#         proto_file = 'test/protocols/test_error_msg.txt'
-#         proto = fc.Protocol(proto_file)
-#         proto.run()
+    def test_protocol_error(self):
+        proto_file = 'test/protocols/test_error_msg.txt'
+        proto = fc.Protocol(proto_file)
+        with pytest.raises(fc.error_handling.ErrorRecorder):
+            proto.run()
 
     def test_parsing_ranges(self):
         # test parsing uniform range

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -665,27 +665,11 @@ class TestSyntaxInterface(unittest.TestCase):
         proto.set_model(Model.TestOdeModel(1))
         proto.run()
 
-    def test_non_existent(self):
-        proto_file = 'protocols/not_here.txt'
-        with pytest.raises(FileNotFoundError):
-            fc.Protocol(proto_file)
-
-    def test_non_existent_library(self):
-        proto_file = 'test/protocols/test_non_existent_library.txt'
-        with pytest.raises(FileNotFoundError):
-            fc.Protocol(proto_file)
-
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)
         expr = parse_action[0].expr()
         for each in expr:
             self.assertIsInstance(each, S.Assign)
-
-    def test_protocol_error(self):
-        proto_file = 'test/protocols/test_error_msg.txt'
-        proto = fc.Protocol(proto_file)
-        with pytest.raises(fc.error_handling.ErrorRecorder):
-            proto.run()
 
     def test_parsing_ranges(self):
         # test parsing uniform range
@@ -770,4 +754,3 @@ class TestSyntaxInterface(unittest.TestCase):
         expr = parse_action[0].expr()
         self.assertIsInstance(expr, Modifiers.ResetState)
         self.assertEqual(expr.state_name, 'state_name')
-

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -1,5 +1,6 @@
 
 import numpy as np
+import pytest
 import unittest
 
 import fc
@@ -666,21 +667,13 @@ class TestSyntaxInterface(unittest.TestCase):
 
     def test_non_existent(self):
         proto_file = 'protocols/not_here.txt'
-        # for some reason this line reports failure (while also reporting the Exception !!
-        # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
-        try:
+        with pytest.raises(FileNotFoundError):
             fc.Protocol(proto_file)
-        except FileNotFoundError:
-            self.assertTrue(True)
 
     def test_non_existent_library(self):
         proto_file = 'test/protocols/test_non_existent_library.txt'
-        # for some reason this line reports failure (while also reporting the Exception !!
-        # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
-        try:
+        with pytest.raises(FileNotFoundError):
             fc.Protocol(proto_file)
-        except FileNotFoundError:
-            self.assertTrue(True)
 
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -665,12 +665,14 @@ class TestSyntaxInterface(unittest.TestCase):
         proto.run()
 
     def test_non_existent(self):
-        proto_file = 'protocols/not_here.txt'
+        # proto_file = 'protocols/not_here.txt'
         # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
+        pass
 
     def test_non_existent_library(self):
-        proto_file = 'protocols/test_non_existent_library.txt'
+        # proto_file = 'protocols/test_non_existent_library.txt'
         # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
+        pass
 
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -665,14 +665,22 @@ class TestSyntaxInterface(unittest.TestCase):
         proto.run()
 
     def test_non_existent(self):
-        # proto_file = 'protocols/not_here.txt'
+        proto_file = 'protocols/not_here.txt'
+        # for some reason this line reports failure (while also reporting the Exception !!
         # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
-        pass
+        try:
+            fc.Protocol(proto_file)
+        except FileNotFoundError:
+            self.assertTrue(True)
 
     def test_non_existent_library(self):
-        # proto_file = 'protocols/test_non_existent_library.txt'
+        proto_file = 'test/protocols/test_non_existent_library.txt'
+        # for some reason this line reports failure (while also reporting the Exception !!
         # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
-        pass
+        try:
+            fc.Protocol(proto_file)
+        except FileNotFoundError:
+            self.assertTrue(True)
 
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)

--- a/test/test_syntax_interface.py
+++ b/test/test_syntax_interface.py
@@ -668,6 +668,10 @@ class TestSyntaxInterface(unittest.TestCase):
         proto_file = 'protocols/not_here.txt'
         # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
 
+    def test_non_existent_library(self):
+        proto_file = 'protocols/test_non_existent_library.txt'
+        # self.assertRaises(FileNotFoundError, fc.Protocol(proto_file))
+
     def test_parsing_inputs(self):
         parse_action = CSP.inputs.parseString('inputs{X=1}', parseAll=True)
         expr = parse_action[0].expr()


### PR DESCRIPTION
## Description
Some unfound files throw several errors and some just exit quietly

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Fixes #82

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

## TO DO
- [x] protocol file not found
- [x] imported library file not found