### PR TITLE
Stop test_output_folder creating testoutput folder

### DIFF
--- a/fc/file_handling.py
+++ b/fc/file_handling.py
@@ -7,6 +7,9 @@ from .error_handling import ProtocolError
 
 class OutputFolder(object):
     """
+    Manages creation and safe clean-up of folders for protocol output to be written to, in a central location defined by
+    the environment variable ``CHASTE_TEST_OUTPUT``.
+
     This class contains routines providing the key functionality of the C++ classes OutputFileHandler and FileFinder.
     In particular, it allows the creation of output folders within the location set for Chaste output, and safe deletion
     of such folders, without risk of wiping a user's drive due to coding error or dodgy path settings.

--- a/test/test_output_folder.py
+++ b/test/test_output_folder.py
@@ -1,7 +1,8 @@
 
 import os
 import shutil
-import unittest
+
+import pytest
 
 from fc.error_handling import ProtocolError
 from fc.file_handling import OutputFolder
@@ -10,7 +11,7 @@ from fc.file_handling import OutputFolder
 CHASTE_TEST_OUTPUT = '/tmp/chaste_test_output'
 
 
-class TestOutputFolder(unittest.TestCase):
+class TestOutputFolder:
     """Test the OutputFolder class."""
 
     def test_creation_single_folder(self):
@@ -20,56 +21,60 @@ class TestOutputFolder(unittest.TestCase):
         if os.path.exists(single_folder_path):
             shutil.rmtree(single_folder_path)  # So we can test that the line below creates it
         single_folder = OutputFolder('TestOutputFolder_TestSingleFolder')
-        self.assertEqual(single_folder.path, single_folder_path)
-        self.assertTrue(os.path.exists(os.path.join(single_folder_path, OutputFolder.SIG_FILE_NAME)))
+        assert single_folder.path == single_folder_path
+        assert os.path.exists(os.path.join(single_folder_path, OutputFolder.SIG_FILE_NAME))
         # Single level, absolute path provided
         single_folder_2 = OutputFolder(single_folder_path)
-        self.assertEqual(single_folder_2.path, single_folder_path)
+        assert single_folder_2.path == single_folder_path
         # Second level manually
         single_folder.create_subfolder('subfolder')
-        self.assertTrue(os.path.isdir(os.path.join(single_folder_path, 'subfolder')))
-        self.assertTrue(os.path.isfile(os.path.join(single_folder_path, 'subfolder', OutputFolder.SIG_FILE_NAME)))
+        assert os.path.isdir(os.path.join(single_folder_path, 'subfolder'))
+        assert os.path.isfile(os.path.join(single_folder_path, 'subfolder', OutputFolder.SIG_FILE_NAME))
         # Multiple levels at once
         multiple_folder_root = os.path.realpath(os.path.join(CHASTE_TEST_OUTPUT, 'TestOutputFolder_TestMultiFolders'))
         multiple_folder_path = os.path.join(multiple_folder_root, 'L1', 'L2', 'L3')
         if os.path.exists(multiple_folder_root):
             shutil.rmtree(multiple_folder_root)
         OutputFolder(multiple_folder_path)
-        self.assertTrue(os.path.exists(multiple_folder_path))
-        self.assertTrue(os.path.exists(os.path.join(multiple_folder_root, OutputFolder.SIG_FILE_NAME)))
-        self.assertTrue(os.path.exists(os.path.join(multiple_folder_root, 'L1', OutputFolder.SIG_FILE_NAME)))
-        self.assertTrue(os.path.exists(os.path.join(multiple_folder_root, 'L1', 'L2', OutputFolder.SIG_FILE_NAME)))
-        self.assertTrue(os.path.exists(os.path.join(multiple_folder_path, OutputFolder.SIG_FILE_NAME)))
+        assert os.path.exists(multiple_folder_path)
+        assert os.path.exists(os.path.join(multiple_folder_root, OutputFolder.SIG_FILE_NAME))
+        assert os.path.exists(os.path.join(multiple_folder_root, 'L1', OutputFolder.SIG_FILE_NAME))
+        assert os.path.exists(os.path.join(multiple_folder_root, 'L1', 'L2', OutputFolder.SIG_FILE_NAME))
+        assert os.path.exists(os.path.join(multiple_folder_path, OutputFolder.SIG_FILE_NAME))
         # Check we can remove folders we have created
         OutputFolder.remove_output_folder(single_folder_path)
         OutputFolder.remove_output_folder(multiple_folder_root)
-        self.assertFalse(os.path.exists(single_folder_path))
-        self.assertFalse(os.path.exists(multiple_folder_path))
+        assert not os.path.exists(single_folder_path)
+        assert not os.path.exists(multiple_folder_path)
 
-    def test_use_of_environment_variable(self):
+    def test_use_of_environment_variable(self, tmp_path):
         # Check that setting CHASTE_TEST_OUTPUT affects where outputs appear
         original_env_var = os.environ.get('CHASTE_TEST_OUTPUT', None)
         os.environ['CHASTE_TEST_OUTPUT'] = os.path.join(
-            original_env_var or 'testoutput', 'TestOutputFolder_NewTestOutput')
+            original_env_var or str(tmp_path), 'TestOutputFolder_NewTestOutput')
         if os.path.exists(os.environ['CHASTE_TEST_OUTPUT']):
             shutil.rmtree(os.environ['CHASTE_TEST_OUTPUT'])
         new_output_path = os.path.join(os.environ['CHASTE_TEST_OUTPUT'], 'TestUseOfEnvironmentVariable')
         OutputFolder('TestUseOfEnvironmentVariable')
-        self.assertTrue(os.path.exists(new_output_path))
+        assert os.path.exists(new_output_path)
         if original_env_var is not None:
             os.environ['CHASTE_TEST_OUTPUT'] = original_env_var
 
     def test_safety(self):
         """Check that we're prevented from deleting content we shouldn't be able to."""
         # Content that's not under CHASTE_TEST_OUTPUT
-        self.assertRaises(ProtocolError, OutputFolder.remove_output_folder, '/tmp/cannot_delete')
+        with pytest.raises(ProtocolError):
+            OutputFolder.remove_output_folder('/tmp/cannot_delete')
         # Content that doesn't contain the signature file (but is under CHASTE_TEST_OUTPUT)
         testoutput = os.path.join(CHASTE_TEST_OUTPUT, 'TestOutputFolder_TestSafety')
         cannot_delete = os.path.join(testoutput, 'cannot_delete')
         if not os.path.exists(testoutput):
             os.mkdir(testoutput)
         open(cannot_delete, 'w').close()
-        self.assertRaises(ProtocolError, OutputFolder.remove_output_folder, cannot_delete)
-        self.assertRaises(ProtocolError, OutputFolder.remove_output_folder, testoutput)
+        with pytest.raises(ProtocolError):
+            OutputFolder.remove_output_folder(cannot_delete)
+        with pytest.raises(ProtocolError):
+            OutputFolder.remove_output_folder(testoutput)
         # A relative path containing .., putting it outside CHASTE_TEST_OUTPUT
-        self.assertRaises(ProtocolError, OutputFolder, 'folder/../../../../../../etc')
+        with pytest.raises(ProtocolError):
+            OutputFolder('folder/../../../../../../etc')


### PR DESCRIPTION
Fixes #15. Part of #2.

Note that some tests currently fail because this branch hasn't adapted to the latest cellmlmanip changes - will be fixed by #93.