### PR TITLE
Some investigation of parsing speed behaviour

### DIFF
--- a/fc/parsing/CompactSyntaxParser.py
+++ b/fc/parsing/CompactSyntaxParser.py
@@ -9,7 +9,10 @@ from . import actions
 __all__ = ['CompactSyntaxParser']
 
 # Necessary for reasonable speed when using infixNotation
-p.ParserElement.enablePackrat()
+# Also, we force re-enable packrat, because matplotlib can have done it already with different settings!
+p.ParserElement._packratEnabled = False
+p.ParserElement.resetCache()
+p.ParserElement.enablePackrat(None)
 
 
 ################################################################################
@@ -583,7 +586,8 @@ class CompactSyntaxParser(object):
             raise RuntimeError("Failed to parse expression even with a recursion limit of %d; giving up!"
                                % (int(self._stack_depth_factor * self._original_stack_limit),))
         actions.source_file = orig_source_file
-        print('Packrat stats: hits={} misses={}'.format(*p.ParserElement.packrat_cache_stats), file=sys.stderr)
+        print('Packrat stats: len={}, hits={}, misses={}'.format(
+            p.ParserElement.packrat_cache.__len__(), *p.ParserElement.packrat_cache_stats), file=sys.stderr)
         p.ParserElement.resetCache()
         return r
 

--- a/fc/parsing/CompactSyntaxParser.py
+++ b/fc/parsing/CompactSyntaxParser.py
@@ -547,7 +547,8 @@ class CompactSyntaxParser(object):
         # basis that if one expression needs to, several are likely to.
         self._stack_depth_factor = 1
         self._original_stack_limit = sys.getrecursionlimit()
-        self.increase_stack_depth_limit()
+        print('Original stack limit:', self._original_stack_limit, file=sys.stderr)
+        self.increase_stack_depth_limit(step=1.0)
 
     def __del__(self):
         """Reset the stack limit if it changed."""
@@ -555,7 +556,7 @@ class CompactSyntaxParser(object):
 
     def increase_stack_depth_limit(self, step=0.5):
         """Increase the limit by the given factor of the original."""
-        self._stack_depth_factor += 0.5
+        self._stack_depth_factor += step
         new_limit = int(
             self._stack_depth_factor * self._original_stack_limit)
         print('Increasing recursion limit to', new_limit,
@@ -582,6 +583,8 @@ class CompactSyntaxParser(object):
             raise RuntimeError("Failed to parse expression even with a recursion limit of %d; giving up!"
                                % (int(self._stack_depth_factor * self._original_stack_limit),))
         actions.source_file = orig_source_file
+        print('Packrat stats: hits={} misses={}'.format(*p.ParserElement.packrat_cache_stats), file=sys.stderr)
+        p.ParserElement.resetCache()
         return r
 
 ################################################################################


### PR DESCRIPTION
Some investigating around #112. Run tests with `-s` flag to see the pyparsing debug output.

Bizarrely, with `time pytest test/test_algebraic_models.py -s` the second protocol always throws a recursion error, even though it's almost identical to the first and the cache has been reset. So there seems to be something a little screwy going on with shared state: this doesn't happen if it's the only test you run (with an extra `-k init`).

The packrat cache seems to be hit about as often as it's missed, which suggests that it is having some benefit. I discovered when trying to increase its size that matplotlib enables it before we get there, so have added a hacky re-enable in!

Feel free to have a play @MichaelClerx :)

https://stackoverflow.com/questions/51412184/pyparsing-packrat-slows-down-performance may be worth a read.