### PR TITLE
Check that units_of is evaluated at the right time

### DIFF
--- a/fc/parsing/actions.py
+++ b/fc/parsing/actions.py
@@ -1526,7 +1526,7 @@ class ModelInterface(BaseGroupAction):
                         # Both will raise a MissingVariableError if they can't be resolved.
                         try:
                             rhs = rhs.to_sympy(self._variable_generator, self._number_generator)
-                        except MissingVariableError as e:
+                        except MissingVariableError:
                             # Unable to create at this time, but may be able to at a next pass
                             todo.append(pvar)
                             continue
@@ -1563,7 +1563,7 @@ class ModelInterface(BaseGroupAction):
                         rhs = pvar.default_expr if pvar.equation is None else pvar.equation.rhs
                         try:
                             rhs = rhs.to_sympy(self._variable_generator, self._number_generator)
-                        except MissingVariableError as e:
+                        except MissingVariableError:
                             # Unable to create at this time, but may be able to at a next pass
                             todo.append(pvar)
                             continue

--- a/fc/parsing/actions.py
+++ b/fc/parsing/actions.py
@@ -1280,6 +1280,9 @@ class ModelInterface(BaseGroupAction):
 
         Used by :meth:`convert_equations_to_sympy`.
 
+        May raise a :class:`MissingVariableError` if the number's units are set with ``units_of(x)`` where ``x`` is a
+        variable not (yet) known to the model.
+
         :param value: the numerical value
         :param units: the *name* of the units for this quantity. Will be looked up from the protocol's definitions.
             Alternatively, this can be a string ``units_of(variable)`` where ``variable`` is an ontology term for a
@@ -1287,10 +1290,8 @@ class ModelInterface(BaseGroupAction):
         """
         if units.startswith('units_of('):
             name = units[9:-1]
-            try:
-                var = self._variable_generator(name)
-            except KeyError:
-                raise ProtocolError(f'Unknown variable referenced in units_of(): {name}.')
+            # Get variable. This may trigger a MissingVariableError.
+            var = self._variable_generator(name)
             units = var.units
         else:
             units = self.units.get_unit(units)
@@ -1522,7 +1523,10 @@ class ModelInterface(BaseGroupAction):
                                 raise ProtocolError(f'No units specified for non-optional variable {pvar.long_name}.')
 
                         # Try getting sympy RHS
-                        # TODO: There's probably a faster way to check if we can resolve all variables in the RHS
+                        # Note: This involves checking both variable dependencies, and dependencies on units of
+                        # variables via numbers in ``units_of(..)``. So it's not enough at this point that all variables
+                        # we depend on are resolved, we also need all variables mentioned in units_of() to be resolved.
+                        # Both will raise a MissingVariableError if they can't be resolved.
                         try:
                             rhs = rhs.to_sympy(self._variable_generator, self._number_generator)
                         except MissingVariableError as e:

--- a/fc/parsing/actions.py
+++ b/fc/parsing/actions.py
@@ -1478,9 +1478,6 @@ class ModelInterface(BaseGroupAction):
         todo = deque(self.protocol_variables)
         while todo:
 
-            # A potential MissingVariableError encountered in this pass
-            error = None
-
             # Perform a single pass over the todo-variables, and check that at least one gets done
             done = False
             for i in range(len(todo)):
@@ -1532,7 +1529,6 @@ class ModelInterface(BaseGroupAction):
                         except MissingVariableError as e:
                             # Unable to create at this time, but may be able to at a next pass
                             todo.append(pvar)
-                            error = e
                             continue
 
                         # Get units for the variable to create from its RHS, fixing inconsistencies if required
@@ -1570,7 +1566,6 @@ class ModelInterface(BaseGroupAction):
                         except MissingVariableError as e:
                             # Unable to create at this time, but may be able to at a next pass
                             todo.append(pvar)
-                            error = e
                             continue
 
                     # Get sympy lhs
@@ -1634,10 +1629,10 @@ class ModelInterface(BaseGroupAction):
             if not done:
                 # No changes in iteration implies there are missing variables in the RHS of at least one variable.
                 # Create a ProtocolError based on the last MissingVariableError
-                assert error is not None, 'No changes made when resolving equations, but no error set'
+                todo = ', '.join([pvar.name for pvar in todo])
                 raise ProtocolError(
-                    'Unable to resolve all references in the protocol equations: ' + str(error)
-                ) from error
+                    f'Unable to create or set equations for {todo}: Please check model interface for units information'
+                    f' or unknown references in these variables right-hand side.')
 
     def _handle_clamping(self):
         """Clamp requested variables to their initial values."""

--- a/test/protocols/test_units_of.txt
+++ b/test/protocols/test_units_of.txt
@@ -1,0 +1,71 @@
+#
+# Tests using units_of
+#
+# Designed to run with simple_ode.cellml, which contains only three annotations:
+#  - cytosolic_sodium_concentration
+#  - membrane_voltage
+#  - time
+#
+
+namespace oxmeta = "https://chaste.comlab.ox.ac.uk/cellml/ns/oxford-metadata#"
+
+units {
+    molar = mole . litre^-1
+    millimolar = milli molar
+    ms = milli second
+    MV = mega volt
+}
+
+model interface {
+    independent var units ms
+
+    # Don't redefine units of cytosolic_sodium_concentration
+    input oxmeta:cytosolic_sodium_concentration = 1
+    output oxmeta:cytosolic_sodium_concentration
+
+    # Create a variable in the units of yet-to-be created variables (mM)
+    define oxmeta:extracellular_potassium_concentration = 100 :: units_of(oxmeta:extracellular_calcium_concentration) + 200 :: units_of(oxmeta:extracellular_sodium_concentration)
+    output oxmeta:extracellular_potassium_concentration
+
+    # Create a variable in the units of yet-to-be created variables (mM)
+    define oxmeta:extracellular_calcium_concentration = 20 :: units_of(oxmeta:extracellular_sodium_concentration)
+    output oxmeta:extracellular_calcium_concentration
+
+    # Create a variable in the original units of an existing model variable (4 mM)
+    define oxmeta:extracellular_sodium_concentration = 4 :: units_of(oxmeta:cytosolic_sodium_concentration)
+    output oxmeta:extracellular_sodium_concentration
+
+    # Create a variable so that we can read the output (M)
+    define oxmeta:extracellular_chloride_concentration = oxmeta:extracellular_potassium_concentration + oxmeta:extracellular_calcium_concentration + oxmeta:extracellular_sodium_concentration
+    output oxmeta:extracellular_chloride_concentration units molar
+
+    # Create a variable in converted units of existing variable
+    define oxmeta:sodium_reversal_potential = 1 :: units_of(oxmeta:membrane_voltage)
+    output oxmeta:sodium_reversal_potential
+
+    # Convert units of membrane voltage to mega volts
+    input oxmeta:membrane_voltage = 0.1
+    output oxmeta:membrane_voltage units MV
+
+    # Create another variable in mV, to read out the value
+    define oxmeta:potassium_reversal_potential = oxmeta:sodium_reversal_potential
+    output oxmeta:potassium_reversal_potential units volt
+}
+
+tasks {
+    simulation sim = timecourse {
+        range t units ms uniform 0:1
+    }
+}
+
+post-processing {
+    assert sim:cytosolic_sodium_concentration[0] == 1
+    assert sim:extracellular_potassium_concentration[0] == 300
+    assert sim:extracellular_calcium_concentration[0] == 20
+    assert sim:extracellular_sodium_concentration[0] == 4
+    assert sim:extracellular_chloride_concentration[0] == 0.324
+    assert sim:sodium_reversal_potential[0] == 1
+    assert sim:membrane_voltage[0] == 0.1
+    assert sim:potassium_reversal_potential[0] == 1000000
+}
+

--- a/test/protocols/test_units_of.txt
+++ b/test/protocols/test_units_of.txt
@@ -47,7 +47,7 @@ model interface {
     input oxmeta:membrane_voltage = 0.1
     output oxmeta:membrane_voltage units MV
 
-    # Create another variable in mV, to read out the value
+    # Create another variable in volts, to read out the value
     define oxmeta:potassium_reversal_potential = oxmeta:sodium_reversal_potential
     output oxmeta:potassium_reversal_potential units volt
 }
@@ -68,4 +68,3 @@ post-processing {
     assert sim:membrane_voltage[0] == 0.1
     assert sim:potassium_reversal_potential[0] == 1000000
 }
-

--- a/test/test_units_of.py
+++ b/test/test_units_of.py
@@ -4,7 +4,7 @@ Tests the units_of() construct when giving units to numbers.
 import fc
 
 
-def test_unit_of():
+def test_units_of():
     # Tests the units_of construct
 
     proto_file = 'test/protocols/test_units_of.txt'

--- a/test/test_units_of.py
+++ b/test/test_units_of.py
@@ -9,8 +9,7 @@ def test_unit_of():
 
     proto_file = 'test/protocols/test_units_of.txt'
     proto = fc.Protocol(proto_file)
-    proto.set_output_folder('test_unit_of')
+    proto.set_output_folder('test_units_of')
     proto.set_model('test/data/simple_ode.cellml')
     proto.run()
     # Test assertions are within the protocol itself
-

--- a/test/test_units_of.py
+++ b/test/test_units_of.py
@@ -1,0 +1,16 @@
+"""
+Tests the units_of() construct when giving units to numbers.
+"""
+import fc
+
+
+def test_unit_of():
+    # Tests the units_of construct
+
+    proto_file = 'test/protocols/test_units_of.txt'
+    proto = fc.Protocol(proto_file)
+    proto.set_output_folder('test_unit_of')
+    proto.set_model('test/data/simple_ode.cellml')
+    proto.run()
+    # Test assertions are within the protocol itself
+


### PR DESCRIPTION
See #106 

If units get redefined, it's important that units_of points to the new units.

Units can get set in two ways:

1. through an input/output statement
2. when a new variable is created

Thoughts so far:

- `units_of()` can only occur in the units of a number
- the `units_of` is evaluated when the number is converted to sympy
- the expressions don't get converted until existing variables have been converted. So case 1 is solved.
- I've updated the code so that if a number can't find the variable for its `units_of()` it raises a MissingVariableError.
- This then propagates and is caught in the model modification code (which will stop processing and hope to fix it on the next pass). So `units_of` is taken into account when creating and modifying variables. This solves case 2.

Still need to add tests