### PR TITLE
Cellmlmanip changes

### DIFF
--- a/fc/code_generation.py
+++ b/fc/code_generation.py
@@ -129,7 +129,7 @@ def get_unique_names(model):
     return variables
 
 
-def create_weblab_model(path, class_name, model, ns_map, protocol_variables):
+def create_weblab_model(path, class_name, model, time_variable, ns_map, protocol_variables):
     """
     Takes a :class:`cellmlmanip.Model`, generates a ``.pyx`` model for use with
     the Web Lab, and stores it at ``path``.
@@ -141,7 +141,9 @@ def create_weblab_model(path, class_name, model, ns_map, protocol_variables):
     ``class_name``
         A name for the generated class.
     ``model``
-        A :class:`cellmlmanip.Model` object.
+        A :class:`cellmlmanip.model.Model` object.
+    ``time_variable``
+        A :class:`cellmlmanip.model.VariableDummy` object representing time.
     ``ns_map``
         A dict mapping namespace prefixes to namespace URIs.
     ``protocol_variables``
@@ -170,7 +172,7 @@ def create_weblab_model(path, class_name, model, ns_map, protocol_variables):
     printer = WebLabPrinter(variable_name, derivative_name)
 
     # Create free variable name
-    free_name = variable_name(model.get_free_variable())
+    free_name = variable_name(time_variable)
 
     # Create state information dicts
     state_info = []

--- a/fc/parsing/actions.py
+++ b/fc/parsing/actions.py
@@ -1219,7 +1219,7 @@ class ModelInterface(BaseGroupAction):
     #######################################
     # Model manipulation and helper methods
 
-    def modify_model(self, model, units):
+    def modify_model(self, model, time_variable, units):
         """Use the definitions in this interface to transform the provided model.
 
         This calls various internal helper methods to do the modifications, in an order orchestrated to follow the
@@ -1234,17 +1234,12 @@ class ModelInterface(BaseGroupAction):
         - Model variables and equations not needed to compute the requested outputs are removed.
 
         :param cellmlmanip.model.Model model: the model to manipulate
+        :param cellmlmanip.model.VariableDummy time_variable: the model's time variable
         :param cellmlmanip.units.UnitStore units: the protocol's unit store, for resolving unit references
         """
         self.model = model
+        self.time_variable = time_variable
         self.units = units
-
-        # Models in FC must always have a time variable
-        try:
-            self.time_variable = self.model.get_free_variable()
-        except ValueError:
-            # TODO: Look for variable annotated as time instead?
-            raise ProtocolError('Model must contain at least one ODE.')
 
         # Annotate all state variables with the magic `oxmeta:state_variable` term. This is done before unit conversion
         # so that annotations are transferred where needed. The original order in which state variables were defined is

--- a/fc/parsing/actions.py
+++ b/fc/parsing/actions.py
@@ -1241,6 +1241,9 @@ class ModelInterface(BaseGroupAction):
         self.time_variable = time_variable
         self.units = units
 
+        # Time variable may be replaced, so delete this reference just to be safe
+        del(time_variable)
+
         # Annotate all state variables with the magic `oxmeta:state_variable` term. This is done before unit conversion
         # so that annotations are transferred where needed. The original order in which state variables were defined is
         # stored.
@@ -1268,6 +1271,9 @@ class ModelInterface(BaseGroupAction):
         self._purge_unused_mathematics()
 
         # TODO: Any final consistency checks on the model?
+
+        # Return new time variable
+        return self.time_variable
 
     def _variable_generator(self, name):
         """Resolve a name reference within a model interface equation to a variable in the model.

--- a/fc/protocol.py
+++ b/fc/protocol.py
@@ -630,14 +630,22 @@ class Protocol(object):
             import cellmlmanip
             model = cellmlmanip.load_model(model, self.units)
 
+            # Check whether the model has a time variable. If not, create one
+            try:
+                time_variable = model.get_free_variable()
+            except ValueError:
+                time_variable = model.create_unique_name('time')
+                time_variable = model.add_variable(time, self.units.get('seconds'))
+
             # Do all the transformations specified by the protocol
-            self.model_interface.modify_model(model, self.units)
+            self.model_interface.modify_model(model, time_variable, self.units)
 
             # Create weblab model at path
             create_weblab_model(
                 path,
                 class_name,
                 model,
+                time_variable,
                 ns_map=self.ns_map,
                 protocol_variables=self.model_interface.protocol_variables,
             )

--- a/fc/protocol.py
+++ b/fc/protocol.py
@@ -638,7 +638,7 @@ class Protocol(object):
                 time_variable = model.add_variable(time, self.units.get('seconds'))
 
             # Do all the transformations specified by the protocol
-            self.model_interface.modify_model(model, time_variable, self.units)
+            time_variable = self.model_interface.modify_model(model, time_variable, self.units)
 
             # Create weblab model at path
             create_weblab_model(

--- a/test/code_generation/weblab_model.pyx
+++ b/test/code_generation/weblab_model.pyx
@@ -52,7 +52,7 @@ cdef int _evaluate_rhs(Sundials.realtype var_time,
     cdef double var_stim_end = 10000.0
     cdef double var_stim_period = 1000.0
     cdef double var_stim_start = 10.0
-    cdef double var_i_Stim = ((var_stim_amplitude) if (var_time >= var_stim_start and var_time <= var_stim_end and var_stim_duration >= -var_stim_start - var_stim_period * math.floor((-var_stim_start + var_time) / var_stim_period) + var_time) else (0.0))
+    cdef double var_i_Stim = ((var_stim_amplitude) if (var_time >= var_stim_start and var_time <= var_stim_end and var_stim_duration >= -var_stim_start - var_stim_period * math.floor((-var_stim_start + var_time) / var_stim_period) + var_time) else (0))
     cdef double var_E_K = -12.0 + var_E_R
     cdef double var_g_K = parameters[1]
     cdef double var_alpha_n = -0.01 * (65.0 + var_V) / (-1.0 + math.exp(-6.5 - 0.1 * var_V))

--- a/test/test_code_generation.py
+++ b/test/test_code_generation.py
@@ -54,6 +54,9 @@ def test_generate_weblab_model(tmp_path):
     model = os.path.join('test', 'models', 'hodgkin_huxley_squid_axon_model_1952_modified.cellml')
     model = cellmlmanip.load_model(model)
 
+    # Time variable
+    time_variable = model.get_free_variable()
+
     # Combined output and parameter information
     protocol_variables = []
     variables = [
@@ -90,6 +93,7 @@ def test_generate_weblab_model(tmp_path):
         str(path),
         class_name,
         model,
+        time_variable,
         ns_map={'oxmeta': OXMETA_NS},
         protocol_variables=protocol_variables,
     )


### PR DESCRIPTION
Handling of the time variable happened correctly only by accident, it turns out:

Old situation in algebraic model tests:

1. Load beeler-reuter, with several ODEs
2. Request time variable --> time gets "type" set by graph()
3. Clamp V, remove all other ODEs
4. Request time variable --> model still finds time variable, as it still has its "free" type

New situation, before this PR:

1. ..
2. Request time variable --> returns same as before, but now by inspecting ODEs
3. ...
4. Request time variable --> unable to find time variable, as all ODEs removed

So now we explicitly store the time variables before model manipulation, and even create one if there aren't any ODEs